### PR TITLE
Fix lib3mf-python building against 3.12 only

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -16,6 +16,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libzip:
 - '1'
+python_min:
+- '3.9'
 target_platform:
 - linux-64
 zlib:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -18,6 +18,8 @@ libzip:
 - '1'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+python_min:
+- '3.9'
 target_platform:
 - osx-64
 zlib:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -18,6 +18,8 @@ libzip:
 - '1'
 macos_machine:
 - arm64-apple-darwin20.0.0
+python_min:
+- '3.9'
 target_platform:
 - osx-arm64
 zlib:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - vs2019
 libzip:
 - '1'
+python_min:
+- '3.9'
 target_platform:
 - win-64
 zlib:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/bld_lib3mf.bat
+++ b/recipe/bld_lib3mf.bat
@@ -9,6 +9,7 @@ cmake ^
     -DLIB3MF_TESTS=OFF ^
     -DCMAKE_BUILD_TYPE:String=Release ^
     -G "NMake Makefiles" ^
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
     ..
 
 cmake --build . --target install

--- a/recipe/build_lib3mf.sh
+++ b/recipe/build_lib3mf.sh
@@ -12,6 +12,7 @@ cmake ${CMAKE_ARGS} \
     -DCMAKE_BUILD_TYPE:String=Release \
     -DLIB3MF_TESTS=OFF \
     -GNinja \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     ..
 
 ninja

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0002-use-ctypes.util-to-find-library.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,19 +44,16 @@ outputs:
   - name: lib3mf-python
     script: build_python.sh
     requirements:
-      build:
-        - pip
-        - python >=3.9                           # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - setuptools
       host:
-        - python >=3.9
+        - python {{ python_min }}
         - pip
         - setuptools
       run:
-        - python >=3.9
+        - python >={{ python_min }}
         - {{ pin_subpackage('lib3mf', exact=True) }}
     test:
+      requires:
+        - python {{ python_min }}
       imports:
         - lib3mf
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ outputs:
   - name: lib3mf-python
     build:
       noarch: python
+      skip: true  # [build_platform != target_platform]
     script: build_python.sh
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 0
+  noarch: python
 
 outputs:
   - name: lib3mf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ source:
 
 build:
   number: 1
-  noarch: python
 
 outputs:
   - name: lib3mf
@@ -42,6 +41,8 @@ outputs:
         - if not exist %PREFIX%\\Library\\lib\\lib3mf.lib exit 1                           # [win]
 
   - name: lib3mf-python
+    build:
+      noarch: python
     script: build_python.sh
     requirements:
       host:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

WIP work to address #16 - looks like maybe a couple of issues:
- The python output not automatically building against multiple packages
- The python output doesn't need to be arch-specific anyhow?