### PR TITLE
Fix lib3mf-python on non-linux platforms

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ outputs:
         - setuptools
       run:
         - python >={{ python_min }}
-        - {{ pin_subpackage('lib3mf', exact=True) }}
+        - {{ pin_subpackage('lib3mf', max_pin='x.x.x') }}
     test:
       requires:
         - python {{ python_min }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0002-use-ctypes.util-to-find-library.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: lib3mf


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Using `pin_subpackage(exact=True)` was causing the noarch python to be pinned to the _exact_ lib3mf that was built alongside. This means that only the linux version worked, as e.g. the linux build string could not be installed on macOS.